### PR TITLE
WIP #9 Unsubscribe error

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -92,6 +92,14 @@ function createMethod(clientMethod, dbg, cancelCache) {
           call.removeListener('error', onError);
         };
 
+        const originalUnsub = observer.unsubscribe;
+        observer.unsubscribe = function(...args) {
+          // like end but with no error
+          // @see https://nodejs.org/api/stream.html#stream_readable_streams
+          call.destroy();
+          originalUnsub.call(observer, ...args);
+        };
+
         call.pipe(though2.obj(onData, onEnd));
         call.on('error', onError);
       }

--- a/src/client.js
+++ b/src/client.js
@@ -4,6 +4,8 @@ const though2 = require('through2');
 const { getServiceNames } = require('../src/utils');
 
 const debug = require('../debug').spawn('client');
+
+const __test__ = {};
 /**
  * @param  {Object} grpcApi - pre-loaded grpcApi
  * @param  {String} methExt - your choice to extend or override the methodNames
@@ -54,6 +56,7 @@ function createMethod(clientMethod, dbg, cancelCache) {
     Subject / vs ReplaySubject might miss some entities!
     */
     const retObs = new Observable(observer => {
+      __test__.current = observer;
       const handler = (error, data) => {
         const d = dbg.spawn('handler');
         if (error) {
@@ -92,13 +95,13 @@ function createMethod(clientMethod, dbg, cancelCache) {
           call.removeListener('error', onError);
         };
 
-        const originalUnsub = observer.unsubscribe;
-        observer.unsubscribe = function(...args) {
-          // like end but with no error
-          // @see https://nodejs.org/api/stream.html#stream_readable_streams
-          call.destroy();
-          originalUnsub.call(observer, ...args);
-        };
+        // const originalUnsub = observer.unsubscribe;
+        // observer.unsubscribe = function(...args) {
+        //   // like end but with no error
+        //   // @see https://nodejs.org/api/stream.html#stream_readable_streams
+        //   call.destroy();
+        //   originalUnsub.call(observer, ...args);
+        // };
 
         call.pipe(though2.obj(onData, onEnd));
         call.on('error', onError);
@@ -163,6 +166,7 @@ function createMethod(clientMethod, dbg, cancelCache) {
 }
 
 module.exports = {
+  __test__,
   create,
   createMethod
 };

--- a/tests/client.spec.js
+++ b/tests/client.spec.js
@@ -58,7 +58,7 @@ describe(`client`, () => {
         });
       }
 
-      it.only('rxWrapper is called once', () => {
+      it('rxWrapper is called once', () => {
         const { server } = initServerPayload;
         makeCall();
         expect(conn.sayMultiHelloRx.calledOnce).to.be.ok;

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -1,13 +1,15 @@
 const { loadObject, credentials } = require('grpc');
 const { loadSync } = require('protobufjs');
 const { expect } = require('chai');
-// const sinon = require('sinon');
+const sinon = require('sinon');
 const { Subject, ReplaySubject, Observable } = require('rxjs');
 
 const getProtoPath = require('./utils/getProtoPath');
 const server = require('../examples/helloworld/impls/server');
 const serverRx = require('../examples/helloworld/impls/serverRx');
 const { toRxClient } = require('../src');
+
+const { __test__ } = require('../src/client');
 
 const toGrpc = loadObject;
 
@@ -173,7 +175,11 @@ function runSuite({ initServer, reply }, serverName) {
             });
 
             describe.only('end early', () => {
-              it('stops early using take operator', done => {
+              afterEach(() => {
+                expect(__test__.current.error.called).not.to.be.ok;
+                expect(__test__.current.next.callCount === 1).to.be.ok;
+              });
+              it.only('stops early using take operator', done => {
                 const callObs = makeCall(false);
                 let actualCalls = 0;
                 const hot = callObs.take(1).subscribe({
@@ -191,10 +197,9 @@ function runSuite({ initServer, reply }, serverName) {
                     done();
                   }
                 });
-                // sinon.spy(hot, 'error');
-                // sinon.spy(hot, 'next');
-                // expect(hot.error.called).not.to.be.ok;
-                // expect(hot.next.called).not.to.be.ok;
+                // expect(__test__.current._parent === hot).to.be.ok;
+                sinon.spy(__test__.current, 'error');
+                sinon.spy(__test__.current, 'next');
                 return hot;
               });
               it('stops early using unsubscribe operator', done => {


### PR DESCRIPTION
The key is the commented out lines in client.js. With these lines commented, take(1) works like expected as in it calls next 1 time, BUT the server continues to stream responses until 2. The only way to see this is via the logs. I can't for the life of me figure out how to write these expectations so they fail.

Here is result of `DEBUG=rxjs-grpc-minimal* yarn test` with client code commented out:

<img width="1497" alt="error" src="https://user-images.githubusercontent.com/22599518/61694416-3ef1cb80-ace6-11e9-89a8-7328d97749b9.png">

And with the client fix un-commented:
<img width="1001" alt="success" src="https://user-images.githubusercontent.com/22599518/61694433-46b17000-ace6-11e9-9664-f1cdf375cd47.png">

The problem is that in both cases the tests pass because I am not able to catch the errors which occur silently when the client has unsubscribed (via take(1)) yet the server continues to stream. 
