### PR TITLE
ci: add tests summary job for branch protection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,3 +22,20 @@ jobs:
       - run: npm install
       - run: npm run lint
       - run: npm run test:coverage
+
+  tests:
+    name: tests
+    needs: [test]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check test results
+        run: |
+          results=($(echo '${{ toJSON(needs.*.result) }}' | jq -r '.[]'))
+          for r in "${results[@]}"; do
+            if [[ "$r" != "success" ]]; then
+              echo "One or more jobs failed: $r"
+              exit 1
+            fi
+          done
+          echo "All jobs passed"


### PR DESCRIPTION
Branch protection requires a check named , but matrix jobs report as , , etc. — no exact match.\n\nThis adds a summary job named  that:\n- Depends on all matrix (and other) jobs\n- Fails if any dependency failed\n- Gives branch protection the exact check name it expects