### PR TITLE
fix: replace through2 with native stream.Transform

### DIFF
--- a/examples/helloworld/impls/server.js
+++ b/examples/helloworld/impls/server.js
@@ -1,6 +1,6 @@
 const grpc = require('@grpc/grpc-js');
 
-const through2 = require('through2');
+const { Transform } = require('stream');
 const debug = require('../../../debug').spawn('test:utils:helloServer');
 
 function mockService() {
@@ -31,7 +31,7 @@ function mockService() {
         cb();
       };
 
-      client.pipe(through2.obj(transform, flush));
+      client.pipe(new Transform({ objectMode: true, transform, flush }));
     },
     sayMultiHello(client) {
       // STREAMING RESPONSE

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   },
   "dependencies": {
     "debug-fabulous": "^2.0.1",
-    "rxjs": "^7.8.1",
-    "through2": "^4.0.2"
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.4.1",

--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,5 @@
 const { Observable } = require('rxjs');
-const though2 = require('through2');
+const { Transform } = require('stream');
 
 const { getServiceNames } = require('../src/utils');
 
@@ -107,7 +107,7 @@ function createMethod(clientMethod, dbg, cancelCache) {
           grpcCancel(false);
         };
 
-        call.pipe(though2.obj(onData, onEnd));
+        call.pipe(new Transform({ objectMode: true, transform: onData, flush: onEnd }));
         call.on('error', onError);
       }
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,5 @@
 const { of, Observable } = require('rxjs');
-const through2 = require('through2');
+const { Transform } = require('stream');
 
 const debug = require('../debug').spawn('server');
 
@@ -57,7 +57,7 @@ function createMethod(rxImpl, name, methods, dbg) {
 function createRequestStream({ call, name, dbg }) {
   dbg(() => 'requestStream');
   return new Observable(observer => {
-    call.pipe(through2.obj(onData, onEnd));
+    call.pipe(new Transform({ objectMode: true, transform: onData, flush: onEnd }));
     call.on('error', onError);
 
     function onError(err) {

--- a/tests/index.nonRx.spec.js
+++ b/tests/index.nonRx.spec.js
@@ -1,4 +1,4 @@
-const through2 = require('through2');
+const { Transform } = require('stream');
 
 const debug = require('../debug').spawn('test:helloworld');
 const { loadProto, grpc } = require('./utils/loadProto');
@@ -81,7 +81,7 @@ describe('helloworld', () => {
                 .once('status', stat => {
                   debug(() => ({ stat }));
                 })
-                .pipe(through2.obj(onData));
+                .pipe(new Transform({ objectMode: true, transform: onData }));
 
               function onData(resp, _enc, cb) {
                 debug({ resp });
@@ -125,10 +125,14 @@ describe('helloworld', () => {
                   debug(() => ({ stat }));
                 })
                 .pipe(
-                  through2.obj(onData, cb => {
-                    completed = true;
-                    reject(new Error('SHOULD NOT COMPLETE'));
-                    cb();
+                  new Transform({
+                    objectMode: true,
+                    transform: onData,
+                    flush: cb => {
+                      completed = true;
+                      reject(new Error('SHOULD NOT COMPLETE'));
+                      cb();
+                    }
                   })
                 );
 

--- a/tests/utils/logStream.js
+++ b/tests/utils/logStream.js
@@ -1,4 +1,4 @@
-const through = require('through2');
+const { Transform } = require('stream');
 const debug = require('../../debug').spawn('logStream');
 
 function logHandle(chunk, _, cb) {
@@ -14,7 +14,7 @@ function logHandle(chunk, _, cb) {
 }
 
 module.exports = function logStream() {
-  return through.obj(logHandle);
+  return new Transform({ objectMode: true, transform: logHandle });
 };
 
 module.exports.logHandle = logHandle;


### PR DESCRIPTION
## Summary

- `through2` v5 went ESM-only ([#118](https://github.com/rvagg/through2/issues/118)) with no CJS compat layer — `require('through2')` no longer resolves, breaking lint and tests
- Every usage in this repo was `through2.obj(transform, flush)`, which is exactly `new Transform({ objectMode: true, transform, flush })` from Node's built-in `stream`
- Drops `through2` from `dependencies` entirely; no new deps, no behaviour change
- Also fixes a pre-existing typo in `src/client.js` (`though2` → `Transform`)

Closes / supersedes dependabot PR #69.

## Files changed

| File | Change |
|------|--------|
| `src/server.js` | `require('through2')` → `require('stream').Transform`, `through2.obj()` → `new Transform(...)` |
| `src/client.js` | same; also fixed `though2` typo |
| `tests/utils/logStream.js` | same |
| `tests/index.nonRx.spec.js` | same (2 call sites) |
| `examples/helloworld/impls/server.js` | same |
| `package.json` | removed `through2` from `dependencies` |

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 5/5 files, 41/41 tests pass (2 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)